### PR TITLE
Simplify type of run(); clarify error messages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 extern crate getopts;
 use getopts::Options;
 use std::env;
+use std::process;
 
 mod runtime;
 mod cgroup;
@@ -8,10 +9,7 @@ mod filesystem;
 mod mount;
 mod namespace;
 
-fn run(rootfs: Option<String>, command_string: Option<String>){
-	let rootfs = rootfs.unwrap();
-	let command_string = command_string.unwrap();
-
+fn run(rootfs: &str, command_string: &str) {
 	let child_command_buffer = command_string.split(" ");
 	let mut child_command_vector = child_command_buffer.collect::<Vec<&str>>();
 	let command = child_command_vector[0];
@@ -20,35 +18,41 @@ fn run(rootfs: Option<String>, command_string: Option<String>){
 	runtime::run_container(&rootfs, command, child_command_vector);
 }
 
-fn print_usage(program: &str, opts: Options) {
+fn print_usage(program: &str, opts: &Options) {
 	let brief = format!("Usage: {} vas-quod [options]", program);
 	print!("{}", opts.usage(&brief));
 }
 
-
 fn main() {
-	
 	let args: Vec<String> = env::args().collect();
 	let program = args[0].clone();
-
 	let mut opts = Options::new();
 	opts.optopt("r", "rootfs", "Path to root file-system eg. --rootfs /home/alpinefs", "path");
 	opts.optopt("c", "command", "Command to be executed eg. --command `curl http://google.com`", "command");
 	opts.optflag("h", "help", "print this help menu");
-	let matches = match opts.parse(&args[1..]) {
-		Ok(m) => { m }
-		Err(_f) => {
-			println!("Error: Unrecognzied Options");
-			print_usage(&program, opts);
-			return
-		}
-	};
-	if matches.opt_present("h") || !matches.opt_present("r") || !matches.opt_present("c") {
-		print_usage(&program, opts);
+
+	let matches = opts.parse(&args[1..]).ok().unwrap_or_else(|| {
+		println!("Error: Unrecognzied options");
+		print_usage(&program, &opts);
+		process::exit(7);
+	});
+
+	// Exits early, but doesn't lead to non-zero exit.
+	if matches.opt_present("h") {
+		print_usage(&program, &opts);
 		return;
 	}
 
-	let rootfs = matches.opt_str("r");
-	let command_string = matches.opt_str("c");
-	run(rootfs, command_string);
+	let rootfs = matches.opt_str("r").unwrap_or_else(|| {
+		println!("Error: Please pass: --rootfs");
+		print_usage(&program, &opts);
+		process::exit(7);
+	});
+	let command_string = matches.opt_str("c").unwrap_or_else(|| {
+		println!("Error: Please pass: --command");
+		print_usage(&program, &opts);
+		process::exit(7);
+	});
+
+	run(&rootfs, &command_string);
 }


### PR DESCRIPTION
This pull request adds:

1. Flatter (less nested) error handling.
2. True error exit codes for some errors.
3. A more robust type signature for `run()`
4. More descriptive error messages.