### PR TITLE
Allow for shell-style or plain word vector exec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple-error"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634bf7bc1315698154cb1b45c1db17fcd2e5ce41f925b7b4063e971536714bf1"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,4 +63,5 @@ version = "0.1.0"
 dependencies = [
  "getopts",
  "nix",
+ "simple-error",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 [dependencies]
 getopts = "0.2"
 nix = "0.19.1"
+simple-error = "0.2.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,7 @@ fn determine_command_tuple<'a, T: AsRef<str> + 'a>(shell_command: &'a Option<T>,
 	// Prepend shell and command string if a command string is given.
 	if let Some(shell_command) = shell_command {
 		vec.push("/bin/sh");
+		vec.push("-c");
 		vec.push(shell_command.as_ref());
 	}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,10 @@
 extern crate getopts;
+extern crate simple_error;
 use getopts::Options;
+use simple_error::require_with;
+use std::cmp::min;
 use std::env;
+use std::error::Error;
 use std::process;
 
 mod runtime;
@@ -9,17 +13,8 @@ mod filesystem;
 mod mount;
 mod namespace;
 
-fn run(rootfs: &str, command_string: &str) {
-	let child_command_buffer = command_string.split(" ");
-	let mut child_command_vector = child_command_buffer.collect::<Vec<&str>>();
-	let command = child_command_vector[0];
-	child_command_vector.drain(0..1);
-
-	runtime::run_container(&rootfs, command, child_command_vector);
-}
-
 fn print_usage(program: &str, opts: &Options) {
-	let brief = format!("Usage: {} vas-quod [options]", program);
+	let brief = format!("Usage: {} vas-quod [options] [-- <command> <argument>...]", program);
 	print!("{}", opts.usage(&brief));
 }
 
@@ -29,9 +24,13 @@ fn main() {
 	let mut opts = Options::new();
 	opts.optopt("r", "rootfs", "Path to root file-system eg. --rootfs /home/alpinefs", "path");
 	opts.optopt("c", "command", "Command to be executed eg. --command `curl http://google.com`", "command");
-	opts.optflag("h", "help", "print this help menu");
+	opts.optflag("h", "help", "Print this help menu");
 
-	let matches = opts.parse(&args[1..]).ok().unwrap_or_else(|| {
+	// Find the conventional "--" that separates out remaing arguments.
+	let end_processable = args.iter().position(|s| s == "--").unwrap_or_else(|| args.len());
+	let begin_unprocessable = min(end_processable + 1, args.len());
+
+	let matches = opts.parse(&args[1..end_processable]).ok().unwrap_or_else(|| {
 		println!("Error: Unrecognzied options");
 		print_usage(&program, &opts);
 		process::exit(7);
@@ -44,15 +43,42 @@ fn main() {
 	}
 
 	let rootfs = matches.opt_str("r").unwrap_or_else(|| {
-		println!("Error: Please pass: --rootfs");
-		print_usage(&program, &opts);
-		process::exit(7);
-	});
-	let command_string = matches.opt_str("c").unwrap_or_else(|| {
-		println!("Error: Please pass: --command");
+		println!("Error: Please pass `--rootfs <path>`");
 		print_usage(&program, &opts);
 		process::exit(7);
 	});
 
-	run(&rootfs, &command_string);
+	let c = matches.opt_str("c"); // NB: Seperate let binding for lifetime.
+	let (command, args) = determine_command_tuple(&c, &args[begin_unprocessable..args.len()]).ok().unwrap_or_else(|| {
+		println!("Error: Please pass `--command <shell command>` or `-- <command> <argument>...`");
+		print_usage(&program, &opts);
+		process::exit(7);
+	});
+
+	runtime::run_container(&rootfs, command, args);
+}
+
+/// Determines based on the inputs whether we are going to invoke a shell, with
+/// shell interpretation, or a simple unescaped argument vector.
+/// Rearranges arguments as needed, but doesn't reallocate.
+fn determine_command_tuple<'a, T: AsRef<str> + 'a>(shell_command: &'a Option<T>, argv: &'a [T]) -> Result<(&'a str, Vec<&'a str>), Box<dyn Error>> {
+	let mut vec: Vec<&str> = vec![];
+
+	// Prepend shell and command string if a command string is given.
+	if let Some(shell_command) = shell_command {
+		vec.push("/bin/sh");
+		vec.push(shell_command.as_ref());
+	}
+
+	// The args given will be the whole command if there's no shell string;
+	// otherwise, they'll be added to the argument vector.
+	vec.extend(argv.iter().map(|item| item.as_ref()));
+
+	// Shift off the first word as the command, erroring out if no command is
+	// given.
+	vec.reverse();
+	let command = require_with!(vec.pop(), "Empty command!");
+	vec.reverse();
+
+	return Ok((command, vec));
 }


### PR DESCRIPTION
What do you think about this change?

The old style of execution did apply shell-like word splitting, but didn't allow the use of a more general shell command. On the other hand, it didn't allow passing args unescaped, either.
