### PR TITLE
Filesystem isolation fix: Switch to pivot_root for mounting rootfs

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,8 +1,17 @@
+use std::fs;
+use std::path::PathBuf;
 use nix::unistd;
+use nix::sys::stat;
+use nix::{Error, Result};
 
 static ROOT_PATH: &str = "/";
+static OLD_ROOT_PATH: &str = ".oldroot";
 
 pub fn set_root_fs(rootfs: &str){
-	unistd::chroot(rootfs).unwrap();
-	let _status = unistd::chdir(ROOT_PATH);
+	
+	let p_root_fs = PathBuf::from(rootfs).join(OLD_ROOT_PATH);
+	let _rm_status = fs::remove_dir_all(&p_root_fs).map_err(|_| Error::InvalidPath);
+	let _mkdir_status = unistd::mkdir(&p_root_fs, stat::Mode::S_IRWXU | stat::Mode::S_IRWXG | stat::Mode::S_IRWXO,);
+	let _pivot_root_status = unistd::pivot_root(rootfs, &p_root_fs);
+	let _chdir_status = unistd::chdir(ROOT_PATH);
 }

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -1,10 +1,19 @@
 use nix::mount;
 
 static PROC: &str = "proc";
+static OLD_ROOT_PATH: &str = "/.oldroot";
 
 pub fn mount_proc(){
 	const NONE: Option<&'static [u8]> = None;
 	mount::mount(Some(PROC), PROC, Some(PROC), mount::MsFlags::empty(), NONE).expect("Failed to mount the /proc");
+}
+
+pub fn mount_root_fs(rootfs: &str){
+	let _status = mount::mount(Some(rootfs),rootfs,None::<&str>,mount::MsFlags::MS_BIND | mount::MsFlags::MS_REC,None::<&str>,);
+}
+
+pub fn unmount_host_root_fs(){
+	let _status = mount::umount2(OLD_ROOT_PATH, mount::MntFlags::MNT_DETACH);
 }
 
 pub fn unmount_proc(){

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -21,8 +21,10 @@ fn spawn_child(hostname: &str, cgroup_name: &str, rootfs: &str, command: &str, c
 	namespace::create_isolated_namespace();	
 	cgroup::cgroup_init(cgroup_name);
 	set_hostname(hostname);
-	
+
+	mount::mount_root_fs(rootfs);	
 	filesystem::set_root_fs(rootfs);
+	mount::unmount_host_root_fs();
 	mount::mount_proc();	
 	
 	Command::new(command).args(command_args).spawn().expect("Failed to execute container command").wait().unwrap();


### PR DESCRIPTION
Following PR fixes:https://github.com/flouthoc/vas-quod/issues/1
Containers could easily break filesystem isolation using `nsenter --mount=/proc/self/ns/mnt ls /home` following scenario has been fixed in this Pull Request.